### PR TITLE
Getting "turn_on" value from .env file

### DIFF
--- a/src/config/easy-detect.php
+++ b/src/config/easy-detect.php
@@ -16,7 +16,7 @@ return [
     /**
      * Turn the mailing report on or off by using boolean value
      */
-    'turn_on' => true,
+    'turn_on' => env('EASY_DETECT_TURN_ON', true),
 
     /**
      * The cache duration in minutes


### PR DESCRIPTION
By having this flexibility, developer can set the value based on the environment. For example, they can always return `false` for the `turn_on` value. By default, it will always return `true`. So if they forgot to change the value, they can change it from the production `.env` file.